### PR TITLE
ocktokit version 4.25.0

### DIFF
--- a/.github/workflows/wordcloud.yml
+++ b/.github/workflows/wordcloud.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        gem install octokit -N --silent
+        gem install octokit -v 4.25.0
         pip install wordcloud
 
     - name: Generate New Word Cloud


### PR DESCRIPTION
using older ocktokit version fixes issue :
```
Run ruby <<- EORUBY
To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
/home/runner/work/word-cloud/word-cloud/wordcloud/octokit_client.rb:5:in `<class:OctokitClient>': uninitialized constant Octokit::Preview (NameError)
	from /home/runner/work/word-cloud/word-cloud/wordcloud/octokit_client.rb:3:in `<top (required)>'
	from /home/runner/work/word-cloud/word-cloud/wordcloud/runner.rb:5:in `require_relative'
	from /home/runner/work/word-cloud/word-cloud/wordcloud/runner.rb:5:in `<top (required)>'
	from /opt/hostedtoolcache/Ruby/2.7.1/x64/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
	from /opt/hostedtoolcache/Ruby/2.7.1/x64/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
	from -:1:in `<main>'
Error: Process completed with exit code 1.
```