### PR TITLE
fix: ensure github actions compatibility

### DIFF
--- a/.github/workflows/wordcloud.yml
+++ b/.github/workflows/wordcloud.yml
@@ -26,6 +26,8 @@ jobs:
     - name: Install dependencies
       run: |
         gem install octokit -N --silent
+        gem install faraday -N --silent
+        gem install faraday-retry -N --silent
         pip install wordcloud
 
     - name: Generate New Word Cloud
@@ -45,5 +47,4 @@ jobs:
             repository: ENV.fetch('REPOSITORY'),
             user: ENV.fetch('EVENT_USER_LOGIN'),
           ).run
-
         EORUBY

--- a/wordcloud/octokit_client.rb
+++ b/wordcloud/octokit_client.rb
@@ -1,4 +1,6 @@
 require 'octokit'
+require 'faraday' 
+require 'octokit/client/issues'
 
 class OctokitClient
   PREVIEW_HEADERS = [


### PR DESCRIPTION
Include 'faraday' gem in GitHub Actions workflow for dependencies
and require 'faraday' in OctokitClient to resolve uninitialized constant.